### PR TITLE
docs: update xbc version text and url

### DIFF
--- a/quickstart.html
+++ b/quickstart.html
@@ -66,21 +66,21 @@
           Please note that XSplit Broadcaster PTR version may contain changes that could affect or change the behavior of some methods in the framework.
         </p>
         <div class="download-xbc">
-            <a href="https://cdn2.xsplit.com/download/bc/m37/3.3.1805.0302/xbc_web_installer_3.3.1805.0302.exe" title="Latest Official Build">
+            <a href="https://cdn2.xsplit.com/download/bc/m38/3.6.1811.2318/xbc_web_installer_3.6.1811.2318.exe" title="Latest Build">
             <span class="softwareIcon"></span>
             <span class="softwareInfo">
               <span class="softwareDownloadText">XSplit Broadcaster</span>
-              <span class="softwareVersion">Version 3.3.1805.0302</span>
-              <span class="softwareRelease">| Latest Official Build</span>
+              <span class="softwareVersion">Version 3.6.1811.2318</span>
+              <span class="softwareRelease">| Latest Build</span>
             </span>
             </a>
         </div>
         <div class="download-xbc-ptr">
-          <a href="https://cdn2.xsplit.com/download/bc/m37/3.3.1805.0302/xbc_web_installer_Beta_3.3.1805.0302.exe" title="Latest PTR Build">
+          <a href="https://cdn2.xsplit.com/download/bc/m38/3.6.1811.2318/xbc_web_installer_Beta_3.6.1811.2318.exe" title="Latest PTR Build">
           <span class="softwareIcon"></span>
           <span class="softwareInfo">
             <span class="softwareDownloadText">XSplit Broadcaster PTR</span>
-            <span class="softwareVersion">Version 3.3.1805.0302</span>
+            <span class="softwareVersion">Version 3.6.1811.2318</span>
             <span class="softwareRelease">| Latest PTR Build</span>
           </span>
           </a>

--- a/quickstart.html
+++ b/quickstart.html
@@ -76,11 +76,11 @@
             </a>
         </div>
         <div class="download-xbc-ptr">
-          <a href="https://cdn2.xsplit.com/download/bc/m38/3.6.1811.2318/xbc_web_installer_Beta_3.6.1811.2318.exe" title="Latest PTR Build">
+          <a href="https://cdn2.xsplit.com/download/bc/m39/3.7.1902.0704/xbc_web_installer_Beta_3.7.1902.0704.exe" title="Latest PTR Build">
           <span class="softwareIcon"></span>
           <span class="softwareInfo">
             <span class="softwareDownloadText">XSplit Broadcaster PTR</span>
-            <span class="softwareVersion">Version 3.6.1811.2318</span>
+            <span class="softwareVersion">Version 3.7.1902.0704</span>
             <span class="softwareRelease">| Latest PTR Build</span>
           </span>
           </a>


### PR DESCRIPTION
Closes #40 

P.S. I also removed the text "Original" because on some screens (well at least in my opensuse laptop), the text is getting misplaced due to the text being too long:

![image](https://user-images.githubusercontent.com/687325/51692125-3706e680-2037-11e9-9f74-e787afd9d86f.png)
